### PR TITLE
Validation of random graph construction

### DIFF
--- a/benchmark/bench_graphConstruct/graphconstruct.cpp
+++ b/benchmark/bench_graphConstruct/graphconstruct.cpp
@@ -8,6 +8,7 @@
 #include "perf.h"
 #include "openG.h"
 #include "omp.h"
+#include <algorithm>
 #ifdef SIM
 #include "SIM.h"
 #endif
@@ -112,6 +113,36 @@ void parallel_randomgraph_construction(graph_t &g, size_t vertex_num, size_t edg
 #endif 
 
     }
+
+    cout << "Validating random graph...";
+    // Check to make sure the graph was constructed correctly
+    vector<pair<size_t, size_t>> actual_edges;
+    actual_edges.reserve(edge_num);
+
+    for (vertex_iterator vit = g.vertices_begin(); vit != g.vertices_end(); ++vit)
+    {
+        for (edge_iterator eit = vit->out_edges_begin(); eit != vit->out_edges_end(); ++eit)
+        {
+            actual_edges.push_back(make_pair(vit->id(), eit->target()));
+        }
+    }
+
+    std::sort(edges.begin(), edges.end());
+    std::sort(actual_edges.begin(), actual_edges.end());
+
+    bool match = true;
+    if (edges.size() != actual_edges.size()) {
+        match = false;
+    } else {
+        auto mismatch = std::mismatch(edges.begin(), edges.end(), actual_edges.begin());
+        if (mismatch.first != edges.end()) {
+            match = false;
+        }
+    }
+
+    if (match) { cout << "OK\n"; }
+    else { cout << "FAIL\n"; }
+
 }
 
 //==============================================================//


### PR DESCRIPTION
Parallel random graph construction in GraphBIG is not implemented correctly.

To illustrate the problem, I added validation code to the end of the parallel random graph construction benchmark. It dumps the graph back to an edge list after construction, and then compares with the randomly generated list the graph was constructed from. When I run with more than 1 thread, the validation usually fails, although it occasionally passes. 

C++ standard library containers like `vector`, `list`, and `unordered_map` are not thread-safe. Calling `push_back` concurrently on the same data structure without synchronization is leading to data corruption in this benchmark. Locking each vertex before adding an edge should solve the problem, but this will have a significant impact on performance.